### PR TITLE
Fix symbol b in client representation (redis return binary values)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,8 @@
 from flask import Flask
-from redis import Redis
+from redis import StrictRedis
 
 app = Flask(__name__)
-redis = Redis(host='redis', port=6379)
+redis = StrictRedis(host='redis', port=6379, encoding='utf-8', decode_responses=True)
 
 @app.route('/')
 def hello():


### PR DESCRIPTION
Hello! When I request flask hello service I get response like "Hello World! I have been seen b'1' times.". So, to avoid this 'b' symbol, I setted up default encoding utf-8 and decoding from binary value for redis.